### PR TITLE
chore: Bump chart version to 0.9.12 and update service account name template

### DIFF
--- a/charts/one-beyond-cronjob/Chart.yaml
+++ b/charts/one-beyond-cronjob/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.11
+version: 0.9.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/one-beyond-cronjob/templates/_helpers.tpl
+++ b/charts/one-beyond-cronjob/templates/_helpers.tpl
@@ -54,5 +54,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "one-beyond-cronjob.serviceAccountName" -}}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default .Release.Name .Values.serviceAccount.name }}
 {{- end }}


### PR DESCRIPTION
Chore to rename service account using the release name instead of "default" for empty ones.